### PR TITLE
fix: disable the scientific notation while printing

### DIFF
--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -62,6 +62,9 @@ class Ping : public rclcpp::Node, public QoS
         }
 
         void show_result() {
+            // Disable the scientific notation globally
+            std::cout << std::fixed;
+
             sort(this->result_.begin(), this->result_.end());
             size_t result_size = this->result_.size();
             std::cout << "RTT min(us):" << this->result_[0] << ",";


### PR DESCRIPTION
To address the issue of improper format being parsed.

```txt
RTT min(us):14244.7,RTT max(us):2.29379e+06,RTT median(us):1.07134e+06,Loss:759
```



